### PR TITLE
feat: PDF generation and multi-company safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,7 @@ composer install
 php artisan key:generate
 php artisan migrate --seed
 php artisan serve --host=127.0.0.1 --port=8000
+```
 
+## Generación de PDF
+Esta aplicación genera PDFs de cotizaciones usando DomPDF. Instala la dependencia `barryvdh/laravel-dompdf` y asegúrate de configurar el logo de la empresa si está disponible.

--- a/app/Http/Middleware/ScopeCompany.php
+++ b/app/Http/Middleware/ScopeCompany.php
@@ -9,7 +9,21 @@ class ScopeCompany
 {
     public function handle(Request $request, Closure $next)
     {
-        // Placeholder middleware for multi-company scoping
+        $user = $request->user();
+        if (!$user || !$user->company_id) {
+            abort(403);
+        }
+
+        $client = $request->route('client');
+        if ($client && $client->company_id !== $user->company_id) {
+            abort(403);
+        }
+
+        $quote = $request->route('quote');
+        if ($quote && $quote->company_id !== $user->company_id) {
+            abort(403);
+        }
+
         return $next($request);
     }
 }

--- a/app/Http/Requests/StoreQuoteRequest.php
+++ b/app/Http/Requests/StoreQuoteRequest.php
@@ -14,6 +14,14 @@ class StoreQuoteRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'client_id' => ['required','exists:clients,id'],
+            'items' => ['required','array','min:1'],
+            'items.*.description' => ['required','string'],
+            'items.*.qty' => ['required','numeric','gt:0'],
+            'items.*.unit_price_cents' => ['required','numeric','gte:0'],
+            'items.*.discount_cents' => ['nullable','numeric','gte:0'],
+            'currency' => ['required','in:PEN,USD'],
+            'expires_at' => ['required','date','after:today'],
             'number' => ['required','string'],
         ];
     }

--- a/app/Http/Requests/UpdateQuoteRequest.php
+++ b/app/Http/Requests/UpdateQuoteRequest.php
@@ -14,6 +14,14 @@ class UpdateQuoteRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'client_id' => ['required','exists:clients,id'],
+            'items' => ['required','array','min:1'],
+            'items.*.description' => ['required','string'],
+            'items.*.qty' => ['required','numeric','gt:0'],
+            'items.*.unit_price_cents' => ['required','numeric','gte:0'],
+            'items.*.discount_cents' => ['nullable','numeric','gte:0'],
+            'currency' => ['required','in:PEN,USD'],
+            'expires_at' => ['required','date','after:today'],
             'number' => ['required','string'],
         ];
     }

--- a/app/Mail/QuoteSentMail.php
+++ b/app/Mail/QuoteSentMail.php
@@ -3,6 +3,7 @@
 namespace App\Mail;
 
 use App\Models\Quote;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
@@ -17,7 +18,9 @@ class QuoteSentMail extends Mailable
 
     public function build(): self
     {
+        $pdf = Pdf::loadView('quotes.pdf', ['quote' => $this->quote]);
         return $this->subject('Quote '.$this->quote->number)
-            ->view('quotes.mail');
+            ->view('quotes.mail')
+            ->attachData($pdf->output(), 'quote-'.$this->quote->number.'.pdf');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "barryvdh/laravel-dompdf": "^2.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/resources/views/quotes/pdf.blade.php
+++ b/resources/views/quotes/pdf.blade.php
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <div style="text-align:center;">
+        @if(optional($quote->company)->logo_url)
+            <img src="{{ $quote->company->logo_url }}" alt="Logo" height="80">
+        @endif
+        <h2>Quote {{ $quote->number }}</h2>
+    </div>
+    <p><strong>Client:</strong> {{ $quote->client_name }}<br>
+       @if($quote->client_email){{ $quote->client_email }}<br>@endif
+       @if($quote->client_phone){{ $quote->client_phone }}<br>@endif
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Description</th>
+                <th>Qty</th>
+                <th>Unit Price</th>
+                <th>Discount</th>
+                <th>Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($quote->items as $item)
+            <tr>
+                <td>{{ $item->description }}</td>
+                <td>{{ $item->quantity }}</td>
+                <td>{{ number_format($item->unit_price_cents/100,2) }}</td>
+                <td>{{ number_format($item->discount_cents/100,2) }}</td>
+                <td>{{ number_format($item->line_total_cents/100,2) }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <p style="text-align:right;">
+        <strong>Subtotal:</strong> {{ number_format($quote->subtotal_cents/100,2) }}<br>
+        <strong>Discount:</strong> {{ number_format($quote->discount_cents/100,2) }}<br>
+        <strong>Tax:</strong> {{ number_format($quote->tax_cents/100,2) }}<br>
+        <strong>Total:</strong> {{ number_format($quote->total_cents/100,2) }}
+    </p>
+    @if($quote->notes)
+    <p>{{ $quote->notes }}</p>
+    @endif
+</body>
+</html>

--- a/tests/Feature/ClientsTest.php
+++ b/tests/Feature/ClientsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClientsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createCompany(array $attributes = [])
+    {
+        return Company::create(array_merge([
+            'name' => 'Acme Inc',
+            'slug' => 'acme'.uniqid(),
+            'plan' => 'starter',
+            'currency' => 'PEN',
+        ], $attributes));
+    }
+
+    public function test_list_clients_of_user_company(): void
+    {
+        $company = $this->createCompany();
+        $user = User::factory()->create(['company_id' => $company->id, 'role' => 'admin']);
+        $client = Client::factory()->create(['company_id' => $company->id]);
+        $otherClient = Client::factory()->create();
+
+        $response = $this->actingAs($user)->get('/clients');
+        $response->assertOk();
+        $response->assertSee($client->name);
+        $response->assertDontSee($otherClient->name);
+    }
+
+    public function test_can_crud_client_within_company(): void
+    {
+        $company = $this->createCompany();
+        $user = User::factory()->create(['company_id' => $company->id, 'role' => 'admin']);
+
+        $payload = ['name' => 'Client1'];
+        $response = $this->actingAs($user)->post('/clients', $payload);
+        $response->assertRedirect('/clients');
+        $this->assertDatabaseHas('clients', ['name' => 'Client1', 'company_id' => $company->id]);
+
+        $client = Client::where('name', 'Client1')->first();
+        $update = $this->actingAs($user)->put("/clients/{$client->id}", ['name' => 'Updated']);
+        $update->assertRedirect('/clients');
+        $this->assertDatabaseHas('clients', ['id' => $client->id, 'name' => 'Updated']);
+
+        $delete = $this->actingAs($user)->delete("/clients/{$client->id}");
+        $delete->assertRedirect('/clients');
+        $this->assertDatabaseMissing('clients', ['id' => $client->id]);
+    }
+
+    public function test_cannot_access_clients_of_other_company(): void
+    {
+        $company = $this->createCompany();
+        $otherCompany = $this->createCompany(['slug' => 'other'.uniqid()]);
+        $user = User::factory()->create(['company_id' => $company->id, 'role' => 'admin']);
+        $otherClient = Client::factory()->create(['company_id' => $otherCompany->id]);
+
+        $response = $this->actingAs($user)->get("/clients/{$otherClient->id}/edit");
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Feature/QuotesTest.php
+++ b/tests/Feature/QuotesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\QuoteSentMail;
+use App\Models\Client;
+use App\Models\Company;
+use App\Models\Quote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class QuotesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createCompany(array $attributes = [])
+    {
+        return Company::create(array_merge([
+            'name' => 'Acme Inc',
+            'slug' => 'acme'.uniqid(),
+            'plan' => 'starter',
+            'currency' => 'PEN',
+        ], $attributes));
+    }
+
+    public function test_can_create_quote_with_items_and_totals(): void
+    {
+        $company = $this->createCompany();
+        $user = User::factory()->create(['company_id' => $company->id, 'role' => 'admin']);
+        $client = Client::factory()->create(['company_id' => $company->id]);
+
+        $payload = [
+            'number' => 'Q-001',
+            'client_id' => $client->id,
+            'currency' => 'PEN',
+            'expires_at' => now()->addDay()->toDateString(),
+            'items' => [
+                ['description' => 'Service', 'qty' => 2, 'unit_price_cents' => 1500],
+            ],
+        ];
+
+        $response = $this->actingAs($user)->post('/quotes', $payload);
+        $quote = Quote::first();
+        $response->assertRedirect(route('quotes.show', $quote));
+        $this->assertDatabaseHas('budget_quote_items', ['quote_id' => $quote->id, 'description' => 'Service']);
+        $this->assertEquals(3000, $quote->total_cents);
+    }
+
+    public function test_can_send_quote_and_queue_mail(): void
+    {
+        $company = $this->createCompany();
+        $user = User::factory()->create(['company_id' => $company->id, 'role' => 'admin']);
+        $client = Client::factory()->create(['company_id' => $company->id]);
+        $quote = Quote::factory()->create([
+            'company_id' => $company->id,
+            'user_id' => $user->id,
+            'client_id' => $client->id,
+            'client_email' => $client->email,
+        ]);
+
+        Mail::fake();
+        Queue::fake();
+
+        $this->actingAs($user)->post("/quotes/{$quote->id}/send");
+        $quote->refresh();
+        $this->assertEquals('sent', $quote->status);
+        Mail::assertQueued(QuoteSentMail::class, function ($mail) use ($quote) {
+            $mail->build();
+            return $mail->quote->is($quote) && count($mail->attachments) === 1;
+        });
+    }
+
+    public function test_can_accept_and_reject_quote(): void
+    {
+        $company = $this->createCompany();
+        $user = User::factory()->create(['company_id' => $company->id, 'role' => 'admin']);
+        $quote = Quote::factory()->create(['company_id' => $company->id, 'user_id' => $user->id]);
+        $quote2 = Quote::factory()->create(['company_id' => $company->id, 'user_id' => $user->id]);
+
+        $this->actingAs($user)->post("/quotes/{$quote->id}/accept");
+        $this->assertEquals('accepted', $quote->fresh()->status);
+
+        $this->actingAs($user)->post("/quotes/{$quote2->id}/reject");
+        $this->assertEquals('rejected', $quote2->fresh()->status);
+    }
+
+    public function test_cannot_access_quotes_of_other_company(): void
+    {
+        $company = $this->createCompany();
+        $otherCompany = $this->createCompany(['slug' => 'other'.uniqid()]);
+        $user = User::factory()->create(['company_id' => $company->id, 'role' => 'admin']);
+        $otherQuote = Quote::factory()->create(['company_id' => $otherCompany->id]);
+
+        $response = $this->actingAs($user)->get("/quotes/{$otherQuote->id}");
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- implement real quote PDF downloads and mail attachments
- enforce company scoping middleware
- validate quote requests and add coverage tests
- document local setup and PDF generation

## Testing
- `composer require barryvdh/laravel-dompdf` *(fails: CONNECT tunnel failed, response 403)*
- `composer install` *(fails: requires GitHub token)*
- `npm install`
- `npm run build`
- `php artisan migrate:fresh --seed` *(fails: vendor autoload missing)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab45766a1c8324872415332dbfd617