### PR TITLE
chore: enable factories and stable seeding

### DIFF
--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Client extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'company_id',

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Company extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['name','slug','plan','currency'];
 
     public function users(): HasMany { return $this->hasMany(User::class); }

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Quote extends Model
 {
+    use HasFactory;
+
     protected $table = 'budget_quotes';
     protected $fillable = [
         'company_id','user_id','client_id','number','client_name','client_email','client_phone','currency',

--- a/app/Models/QuoteItem.php
+++ b/app/Models/QuoteItem.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class QuoteItem extends Model
 {
+    use HasFactory;
+
     protected $table = 'budget_quote_items';
     protected $fillable = [
         'quote_id','sku','name','description','quantity','unit',

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -24,7 +24,9 @@ class ClientFactory extends Factory
             'tax_id' => $this->faker->unique()->numerify('###########'),
             'address' => $this->faker->address(),
             'notes' => $this->faker->sentence(),
-            'created_by' => User::factory(),
+            'created_by' => User::factory()->state(fn (array $attributes) => [
+                'company_id' => $attributes['company_id'],
+            ]),
         ];
     }
 }

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Company;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Company>
+ */
+class CompanyFactory extends Factory
+{
+    protected $model = Company::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->company();
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'plan' => 'starter',
+            'currency' => 'PEN',
+        ];
+    }
+}

--- a/database/factories/QuoteFactory.php
+++ b/database/factories/QuoteFactory.php
@@ -6,6 +6,7 @@ use App\Models\Quote;
 use App\Models\Company;
 use App\Models\User;
 use App\Models\Client;
+use App\Models\QuoteItem;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -19,8 +20,13 @@ class QuoteFactory extends Factory
     {
         return [
             'company_id' => Company::factory(),
-            'user_id' => User::factory(),
-            'client_id' => Client::factory(),
+            'user_id' => User::factory()->state(fn (array $attributes) => [
+                'company_id' => $attributes['company_id'],
+            ]),
+            'client_id' => Client::factory()->state(fn (array $attributes) => [
+                'company_id' => $attributes['company_id'],
+                'created_by' => $attributes['user_id'],
+            ]),
             'number' => 'Q-' . $this->faker->unique()->numerify('000000'),
             'client_name' => $this->faker->name(),
             'client_email' => $this->faker->safeEmail(),
@@ -29,5 +35,14 @@ class QuoteFactory extends Factory
             'total_cents' => 0,
             'status' => 'draft',
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Quote $quote) {
+            QuoteItem::factory()->count(1)->create(['quote_id' => $quote->id]);
+            $quote->refresh();
+            $quote->save();
+        });
     }
 }


### PR DESCRIPTION
## Summary
- enable `HasFactory` across Company, Client, Quote and QuoteItem models
- add `CompanyFactory` and reinforce existing factories with company-aware relations
- update `DemoSeeder` to use factories and coherent `company_id`/`created_by`

## Testing
- `composer install` (fails: CONNECT tunnel failed, response 403)
- `npm install`
- `npm run build`
- `php artisan migrate:fresh --seed` (fails: vendor autoload missing)
- `php artisan test` (fails: Illuminate\Foundation\Application class not found)


------
https://chatgpt.com/codex/tasks/task_e_68ab87fed80c832488e01407d5b0b0fe