### PR TITLE
chore: enable factories and stable seeding

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -5,12 +5,14 @@ namespace App\Http\Controllers;
 use App\Models\Client;
 use App\Http\Requests\StoreClientRequest;
 use App\Http\Requests\UpdateClientRequest;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class ClientController extends Controller
 {
+    use AuthorizesRequests;
     public function index(Request $request): View
     {
         $this->authorize('viewAny', Client::class);

--- a/app/Http/Controllers/QuoteController.php
+++ b/app/Http/Controllers/QuoteController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Quote;
 use App\Http\Requests\StoreQuoteRequest;
 use App\Http\Requests\UpdateQuoteRequest;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -13,6 +14,7 @@ use App\Mail\QuoteSentMail;
 
 class QuoteController extends Controller
 {
+    use AuthorizesRequests;
     public function index(Request $request): View
     {
         $this->authorize('viewAny', Quote::class);

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Client extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'company_id',

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Company extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['name','slug','plan','currency'];
 
     public function users(): HasMany { return $this->hasMany(User::class); }

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Quote extends Model
 {
+    use HasFactory;
+
     protected $table = 'budget_quotes';
     protected $fillable = [
         'company_id','user_id','client_id','number','client_name','client_email','client_phone','currency',

--- a/app/Models/QuoteItem.php
+++ b/app/Models/QuoteItem.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class QuoteItem extends Model
 {
+    use HasFactory;
+
     protected $table = 'budget_quote_items';
     protected $fillable = [
         'quote_id','sku','name','description','quantity','unit',

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -24,7 +24,9 @@ class ClientFactory extends Factory
             'tax_id' => $this->faker->unique()->numerify('###########'),
             'address' => $this->faker->address(),
             'notes' => $this->faker->sentence(),
-            'created_by' => User::factory(),
+            'created_by' => User::factory()->state(fn (array $attributes) => [
+                'company_id' => $attributes['company_id'] ?? Company::factory(),
+            ]),
         ];
     }
 }

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Company;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Company>
+ */
+class CompanyFactory extends Factory
+{
+    protected $model = Company::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->company();
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'plan' => 'starter',
+            'currency' => 'PEN',
+        ];
+    }
+}

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -15,46 +15,45 @@ class DemoSeeder extends Seeder
 {
     public function run(): void
     {
-        $company = Company::firstOrCreate(
-            ['slug' => 'wasi-digital'],
-            ['name' => 'Wasi Digital', 'plan' => 'starter', 'currency' => 'PEN']
-        );
-
-        $admin = User::firstOrCreate(
-            ['email' => 'admin@wasi.test'],
-            [
-                'name' => 'Admin Wasi',
-                'password' => Hash::make('password'),
-                'company_id' => $company->id,
-                'role' => 'admin',
-                'email_verified_at' => now(),
-                'remember_token' => Str::random(10),
-            ]
-        );
-
-        User::factory()->count(2)->create([
-            'company_id' => $company->id,
-            'role' => 'staff',
+        $company = Company::factory()->create([
+            'name' => 'Wasi Digital',
+            'slug' => 'wasi-digital',
+            'plan' => 'starter',
+            'currency' => 'PEN',
         ]);
 
-        $clients = Client::factory()->count(10)->create([
+        $admin = User::factory()->create([
+            'email' => 'admin@wasi.test',
+            'name' => 'Admin Wasi',
+            'password' => Hash::make('password'),
             'company_id' => $company->id,
-            'created_by' => $admin->id,
+            'role' => 'admin',
+            'email_verified_at' => now(),
+            'remember_token' => Str::random(10),
         ]);
 
-        Quote::factory()->count(20)->create([
-            'company_id' => $company->id,
-            'user_id' => $admin->id,
-        ])->each(function (Quote $quote) use ($clients) {
-            $client = $clients->random();
-            $quote->client_id = $client->id;
-            $quote->client_name = $client->name;
-            $quote->client_email = $client->email;
-            $quote->client_phone = $client->phone;
-            $quote->save();
+        User::factory()->count(2)->for($company)->state(['role' => 'staff'])->create();
 
-            QuoteItem::factory()->count(rand(2,5))->create(['quote_id' => $quote->id]);
-            $quote->save();
-        });
+        $clients = Client::factory()->count(10)
+            ->for($company)
+            ->for($admin, 'creator')
+            ->create();
+
+        Quote::factory()->count(20)
+            ->for($company)
+            ->for($admin)
+            ->state(['client_id' => null])
+            ->create()
+            ->each(function (Quote $quote) use ($clients) {
+                $client = $clients->random();
+                $quote->client()->associate($client);
+                $quote->client_name = $client->name;
+                $quote->client_email = $client->email;
+                $quote->client_phone = $client->phone;
+                $quote->save();
+
+                QuoteItem::factory()->count(rand(1,4))->for($quote)->create();
+                $quote->save();
+            });
     }
 }

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,12 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('clients.index')" :active="request()->routeIs('clients.*')">
+                        {{ __('Clients') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('quotes.index')" :active="request()->routeIs('quotes.*')">
+                        {{ __('Quotes') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -69,6 +75,12 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('clients.index')" :active="request()->routeIs('clients.*')">
+                {{ __('Clients') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('quotes.index')" :active="request()->routeIs('quotes.*')">
+                {{ __('Quotes') }}
             </x-responsive-nav-link>
         </div>
 


### PR DESCRIPTION
## Summary
- enable `HasFactory` across Company, Client, Quote and QuoteItem models
- add `CompanyFactory` and reinforce existing factories with company-aware relations
- update `DemoSeeder` to use factories and coherent `company_id`/`created_by`
- make QuoteFactory resilient to missing user/company IDs and align DemoSeeder usage
- include `AuthorizesRequests` trait in Client and Quote controllers
- add navigation links for Clients and Quotes in layout

## Testing
- `composer install` (fails: CONNECT tunnel failed, response 403)
- `npm install`
- `npm run build`
- `php artisan migrate:fresh --seed` (fails: Failed to open required '/workspace/wasi-budget/vendor/autoload.php')
- `php artisan test` (fails: Failed opening required '/workspace/wasi-budget/vendor/autoload.php')


------
https://chatgpt.com/codex/tasks/task_e_68ab87fed80c832488e01407d5b0b0fe