### PR TITLE
Add Client CRUD UI with company scoping

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -31,12 +31,14 @@ class ClientController extends Controller
 
     public function store(StoreClientRequest $request): RedirectResponse
     {
+        $this->authorize('create', Client::class);
         $data = $request->validated();
         $data['company_id'] = $request->user()->company_id;
         $data['created_by'] = $request->user()->id;
         Client::create($data);
 
-        return redirect()->route('clients.index');
+        return redirect()->route('clients.index')
+            ->with('success', 'Client created successfully.');
     }
 
     public function edit(Client $client): View
@@ -47,17 +49,27 @@ class ClientController extends Controller
 
     public function update(UpdateClientRequest $request, Client $client): RedirectResponse
     {
+        $this->authorize('update', $client);
         $data = $request->validated();
+        $data['company_id'] = $request->user()->company_id;
         $client->update($data);
 
-        return redirect()->route('clients.index');
+        return redirect()->route('clients.index')
+            ->with('success', 'Client updated successfully.');
+    }
+
+    public function show(Client $client): View
+    {
+        $this->authorize('view', $client);
+        return view('clients.show', compact('client'));
     }
 
     public function destroy(Client $client): RedirectResponse
     {
         $this->authorize('delete', $client);
         $client->delete();
-        return redirect()->route('clients.index');
+        return redirect()->route('clients.index')
+            ->with('success', 'Client deleted successfully.');
     }
 }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,6 +19,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        \Illuminate\Support\Facades\Route::bind('client', function ($value) {
+            return \App\Models\Client::where('company_id', auth()->user()->company_id)
+                ->findOrFail($value);
+        });
     }
 }

--- a/resources/views/clients/create.blade.php
+++ b/resources/views/clients/create.blade.php
@@ -1,11 +1,59 @@
 <x-app-layout>
-    <x-slot name="header">New Client</x-slot>
-    <form method="post" action="{{ route('clients.store') }}" class="space-y-4">
-        @csrf
-        <div>
-            <label class="block">Name</label>
-            <input name="name" class="border" />
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">Add Client</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form method="POST" action="{{ route('clients.store') }}" class="space-y-6">
+                        @csrf
+
+                        <div>
+                            <x-input-label for="name" :value="__('Name')" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name')" required autofocus />
+                            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="email" :value="__('Email')" />
+                            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email')" />
+                            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="phone" :value="__('Phone')" />
+                            <x-text-input id="phone" name="phone" type="text" class="mt-1 block w-full" :value="old('phone')" />
+                            <x-input-error :messages="$errors->get('phone')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="tax_id" :value="__('Tax ID')" />
+                            <x-text-input id="tax_id" name="tax_id" type="text" class="mt-1 block w-full" :value="old('tax_id')" />
+                            <x-input-error :messages="$errors->get('tax_id')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="address" :value="__('Address')" />
+                            <textarea id="address" name="address" class="mt-1 block w-full rounded-md border-gray-300">{{ old('address') }}</textarea>
+                            <x-input-error :messages="$errors->get('address')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="notes" :value="__('Notes')" />
+                            <textarea id="notes" name="notes" class="mt-1 block w-full rounded-md border-gray-300">{{ old('notes') }}</textarea>
+                            <x-input-error :messages="$errors->get('notes')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center gap-4">
+                            <x-primary-button>Save</x-primary-button>
+                            <a href="{{ route('clients.index') }}" class="text-gray-600">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <button type="submit" class="px-4 py-2 bg-blue-600 text-white">Save</button>
-    </form>
+    </div>
 </x-app-layout>
+

--- a/resources/views/clients/edit.blade.php
+++ b/resources/views/clients/edit.blade.php
@@ -1,12 +1,60 @@
 <x-app-layout>
-    <x-slot name="header">Edit Client</x-slot>
-    <form method="post" action="{{ route('clients.update', $client) }}" class="space-y-4">
-        @csrf
-        @method('PUT')
-        <div>
-            <label class="block">Name</label>
-            <input name="name" value="{{ old('name', $client->name) }}" class="border" />
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">Edit Client</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form method="POST" action="{{ route('clients.update', $client) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+
+                        <div>
+                            <x-input-label for="name" :value="__('Name')" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $client->name)" required autofocus />
+                            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="email" :value="__('Email')" />
+                            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $client->email)" />
+                            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="phone" :value="__('Phone')" />
+                            <x-text-input id="phone" name="phone" type="text" class="mt-1 block w-full" :value="old('phone', $client->phone)" />
+                            <x-input-error :messages="$errors->get('phone')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="tax_id" :value="__('Tax ID')" />
+                            <x-text-input id="tax_id" name="tax_id" type="text" class="mt-1 block w-full" :value="old('tax_id', $client->tax_id)" />
+                            <x-input-error :messages="$errors->get('tax_id')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="address" :value="__('Address')" />
+                            <textarea id="address" name="address" class="mt-1 block w-full rounded-md border-gray-300">{{ old('address', $client->address) }}</textarea>
+                            <x-input-error :messages="$errors->get('address')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="notes" :value="__('Notes')" />
+                            <textarea id="notes" name="notes" class="mt-1 block w-full rounded-md border-gray-300">{{ old('notes', $client->notes) }}</textarea>
+                            <x-input-error :messages="$errors->get('notes')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center gap-4">
+                            <x-primary-button>Save</x-primary-button>
+                            <a href="{{ route('clients.index') }}" class="text-gray-600">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <button type="submit" class="px-4 py-2 bg-blue-600 text-white">Update</button>
-    </form>
+    </div>
 </x-app-layout>
+

--- a/resources/views/clients/index.blade.php
+++ b/resources/views/clients/index.blade.php
@@ -1,10 +1,58 @@
 <x-app-layout>
-    <x-slot name="header">Clients</x-slot>
-    <div class="py-6">
-        <ul>
-            @foreach($clients as $client)
-                <li>{{ $client->name }}</li>
-            @endforeach
-        </ul>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">Clients</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if (session('success'))
+                <div class="mb-4 font-medium text-sm text-green-600">{{ session('success') }}</div>
+            @endif
+
+            <div class="flex justify-end mb-4">
+                <a href="{{ route('clients.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded">Add Client</a>
+            </div>
+
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    @if($clients->count())
+                        <table class="min-w-full">
+                            <thead>
+                                <tr>
+                                    <th class="px-4 py-2 text-left">Name</th>
+                                    <th class="px-4 py-2 text-left">Email</th>
+                                    <th class="px-4 py-2 text-left">Phone</th>
+                                    <th class="px-4 py-2 text-left">TaxID</th>
+                                    <th class="px-4 py-2 text-left">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($clients as $client)
+                                    <tr>
+                                        <td class="border px-4 py-2">{{ $client->name }}</td>
+                                        <td class="border px-4 py-2">{{ $client->email }}</td>
+                                        <td class="border px-4 py-2">{{ $client->phone }}</td>
+                                        <td class="border px-4 py-2">{{ $client->tax_id }}</td>
+                                        <td class="border px-4 py-2 space-x-2">
+                                            <a href="{{ route('clients.edit', $client) }}" class="text-blue-600">Edit</a>
+                                            <form method="POST" action="{{ route('clients.destroy', $client) }}" class="inline" onsubmit="return confirm('Delete this client?');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="text-red-600">Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                        <div class="mt-4">{{ $clients->links() }}</div>
+                    @else
+                        <p class="mb-4">No clients found.</p>
+                        <a href="{{ route('clients.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded">Add Client</a>
+                    @endif
+                </div>
+            </div>
+        </div>
     </div>
 </x-app-layout>
+

--- a/resources/views/clients/show.blade.php
+++ b/resources/views/clients/show.blade.php
@@ -1,0 +1,21 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ $client->name }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 space-y-2">
+                    <p><strong>Email:</strong> {{ $client->email }}</p>
+                    <p><strong>Phone:</strong> {{ $client->phone }}</p>
+                    <p><strong>Tax ID:</strong> {{ $client->tax_id }}</p>
+                    <p><strong>Address:</strong> {{ $client->address }}</p>
+                    <p><strong>Notes:</strong> {{ $client->notes }}</p>
+                    <a href="{{ route('clients.edit', $client) }}" class="text-blue-600">Edit</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/tests/Feature/ClientTest.php
+++ b/tests/Feature/ClientTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_update_delete_client(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create([
+            'company_id' => $company->id,
+            'role' => 'admin',
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->post(route('clients.store'), [
+            'name' => 'Test Client',
+            'email' => 'test@example.com',
+        ]);
+
+        $response->assertRedirect(route('clients.index'))
+            ->assertSessionHas('success');
+
+        $client = Client::first();
+        $this->assertNotNull($client);
+        $this->assertEquals($user->company_id, $client->company_id);
+        $this->assertEquals($user->id, $client->created_by);
+
+        $response = $this->put(route('clients.update', $client), [
+            'name' => 'Updated Client',
+            'email' => 'updated@example.com',
+            'phone' => '123456789',
+            'tax_id' => 'ABC123',
+            'address' => 'Some street',
+            'notes' => 'Some notes',
+        ]);
+
+        $response->assertRedirect(route('clients.index'))
+            ->assertSessionHas('success');
+
+        $client->refresh();
+        $this->assertEquals('Updated Client', $client->name);
+        $this->assertEquals($user->company_id, $client->company_id);
+
+        $response = $this->delete(route('clients.destroy', $client));
+
+        $response->assertRedirect(route('clients.index'))
+            ->assertSessionHas('success');
+
+        $this->assertSoftDeleted('clients', ['id' => $client->id]);
+    }
+
+    public function test_clients_are_isolated_by_company(): void
+    {
+        $companyA = Company::factory()->create();
+        $companyB = Company::factory()->create();
+
+        $userA = User::factory()->create([
+            'company_id' => $companyA->id,
+            'role' => 'admin',
+        ]);
+
+        $clientA = Client::factory()->create([
+            'company_id' => $companyA->id,
+            'created_by' => $userA->id,
+        ]);
+        $clientB = Client::factory()->create([
+            'company_id' => $companyB->id,
+        ]);
+
+        $this->actingAs($userA);
+
+        $this->get(route('clients.index'))
+            ->assertSee($clientA->name)
+            ->assertDontSee($clientB->name);
+
+        $this->get(route('clients.show', $clientB))
+            ->assertNotFound();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Implement full client CRUD interface with forms, tables, flash messages
- Scope client routes to authenticated company and enforce in controller
- Add feature tests for client CRUD and company isolation

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68ac57f6c8b08324ac135b26269201f3