### PR TITLE
feat: scope queries by company

### DIFF
--- a/app/Http/Middleware/ScopeCompany.php
+++ b/app/Http/Middleware/ScopeCompany.php
@@ -2,14 +2,31 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Client;
+use App\Models\Quote;
 use Closure;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class ScopeCompany
 {
     public function handle(Request $request, Closure $next)
     {
-        // Placeholder middleware for multi-company scoping
+        if (Auth::check()) {
+            $companyId = Auth::user()->company_id;
+
+            $applyScope = function (string $model) use ($companyId): void {
+                $model::addGlobalScope('company', function (Builder $builder) use ($companyId) {
+                    $builder->where('company_id', $companyId);
+                });
+            };
+
+            $applyScope(Client::class);
+            $applyScope(Quote::class);
+        }
+
         return $next($request);
     }
 }
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,8 +15,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->alias([
-            'scope.company' => \App\Http\Middleware\ScopeCompany::class,
+        $middleware->group('auth', [
+            \Illuminate\Auth\Middleware\Authenticate::class,
+            \App\Http\Middleware\ScopeCompany::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@ Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
-Route::middleware(['auth','verified','scope.company'])->group(function () {
+Route::middleware(['auth','verified'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');

--- a/tests/Feature/ScopeCompanyTest.php
+++ b/tests/Feature/ScopeCompanyTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\Quote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ScopeCompanyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_cannot_view_client_of_another_company(): void
+    {
+        $client = Client::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $this->actingAs($otherUser)
+            ->get(route('clients.show', $client))
+            ->assertForbidden();
+    }
+
+    public function test_user_cannot_update_client_of_another_company(): void
+    {
+        $client = Client::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $this->actingAs($otherUser)
+            ->put(route('clients.update', $client), [
+                'name' => 'New Name',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_user_cannot_view_quote_of_another_company(): void
+    {
+        $quote = Quote::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $this->actingAs($otherUser)
+            ->get(route('quotes.show', $quote))
+            ->assertForbidden();
+    }
+
+    public function test_user_cannot_update_quote_of_another_company(): void
+    {
+        $quote = Quote::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $this->actingAs($otherUser)
+            ->put(route('quotes.update', $quote), [
+                'number' => 'Q-123',
+            ])
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- add ScopeCompany middleware to filter Client and Quote queries by authenticated user's company
- register middleware in the auth group and simplify route definitions
- test that users cannot view or modify other company resources

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68ac622435308324b3a07b504cf5ea75